### PR TITLE
Fix Liquid syntax error breaking Pages build

### DIFF
--- a/DATA_DICTIONARY.md
+++ b/DATA_DICTIONARY.md
@@ -59,12 +59,14 @@ Counts are opening+closing pairs (balanced unless noted).
 
 ## Inline markup (non-XML)
 
+{% raw %}
 | Marker | Role | Example |
 |---|---|---|
 | `{#…#}` | Devanagari / SLP1 span | `{#kf#}` |
 | `{%…%}` | Italic text span | `{%also written%}` |
 | `¦` | Definition separator | between headword and gloss |
 | `@` | Cross-reference marker | `@mw` |
+{% endraw %}
 
 ---
 


### PR DESCRIPTION
## Problem

The GitHub Pages build has been failing on `master` since 2026-05-27 with:

```
github-pages 232 | Error: Liquid syntax error (line 65): Tag '{%…%}' was not properly terminated with regexp: /\%\}/
```

Failing run: [actions/runs/26539941482](https://github.com/sanskrit-lexicon/MWS/actions/runs/26539941482).

## Root cause

[DATA_DICTIONARY.md](DATA_DICTIONARY.md) contains a markdown table (lines 62–67 on master) documenting the inline-markup conventions used in `mw.txt`:

| Marker | Role |
|---|---|
| `` `{#…#}` `` | Devanagari / SLP1 span |
| `` `{%…%}` `` | Italic text span |

Jekyll's Liquid engine sees `{%…%}` and tries to parse it as a template tag. The ellipsis isn't valid tag content, so the build aborts before any page renders.

## Fix

Wrap the table in `{% raw %} … {% endraw %}` so Liquid emits the curly braces verbatim. This is the smallest, most robust escape — no content change, just a boundary the templating engine respects.

```diff
 ## Inline markup (non-XML)

+{% raw %}
 | Marker | Role | Example |
 |---|---|---|
 | `{#…#}` | Devanagari / SLP1 span | `{#kf#}` |
 | `{%…%}` | Italic text span | `{%also written%}` |
 | `¦` | Definition separator | between headword and gloss |
 | `@` | Cross-reference marker | `@mw` |
+{% endraw %}
```

## Verification

Once merged, the next push to `master` re-triggers `pages-build-deployment.yml`; the run should conclude `success` and the documentation site should re-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)