### PR TITLE
Wrap files with literal {{...}} correction-records in {% raw %} (Pages build fix)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,4 @@
+{% raw %}
 # Contributing to MWS
 
 MWS is a corrections and enhancements repository for the Cologne digitisation of
@@ -118,3 +119,4 @@ for the org-wide taxonomy.
 
 All contributors are expected to follow the
 [CDSL Code of Conduct](CODE_OF_CONDUCT.md).
+{% endraw %}

--- a/DATA_DICTIONARY.md
+++ b/DATA_DICTIONARY.md
@@ -1,3 +1,4 @@
+{% raw %}
 # Data Dictionary — MWS
 
 Tag inventory and field reference for `csl-orig/v02/mw/mw.txt`.
@@ -59,14 +60,12 @@ Counts are opening+closing pairs (balanced unless noted).
 
 ## Inline markup (non-XML)
 
-{% raw %}
 | Marker | Role | Example |
 |---|---|---|
 | `{#…#}` | Devanagari / SLP1 span | `{#kf#}` |
 | `{%…%}` | Italic text span | `{%also written%}` |
 | `¦` | Definition separator | between headword and gloss |
 | `@` | Cross-reference marker | `@mw` |
-{% endraw %}
 
 ---
 
@@ -151,3 +150,4 @@ Grammatical-category abbreviations are placed in `<lex>…</lex>` instead of
 These arise where a tooltip expansion is baked directly into the tag rather than
 looked up from the abbreviation table. All 12,779 have real (non-placeholder)
 expansions as of the 2026-05 markup-fix audit.
+{% endraw %}

--- a/ENTRY_GUIDE.md
+++ b/ENTRY_GUIDE.md
@@ -1,3 +1,4 @@
+{% raw %}
 # Entry Reading Guide — MWS
 
 A practical reference for reading and interpreting entries in `mw.txt`. Worked
@@ -149,14 +150,12 @@ A single-letter optional suffix marks variants. Full inventory in [Entry hierarc
 
 ### Inline non-XML markup
 
-{% raw %}
 | Marker | Role | Example |
 |---|---|---|
 | `¦` | Separator between headword and gloss body | `<s>aMSa</s> ¦ <lex>m.</lex> …` |
 | `{#…#}` | Devanagari / SLP1 inline span (rendered as Devanagari) | `{#kf#}` → कृ |
 | `{%…%}` | Italic text span (rendered as italic in display) | `{%also written%}` |
 | `<srs/>` | Self-closing visarga-ligature marker | `<srs/>` |
-{% endraw %}
 
 ### Correction-record format
 
@@ -173,7 +172,6 @@ In-file corrections use double-brace syntax (processed by [`updateByLine.py`](ht
 Tag counts shown are from the markup-fix audit of `mw.txt` (2026-05) — see
 [DATA_DICTIONARY.md](DATA_DICTIONARY.md) for the full inventory.
 
-{% raw %}
 | Tag | Count | Role | Example |
 |---|--:|---|---|
 | `<s>…</s>` | 350,610 | Sanskrit text span | `<s>aMSa</s>` |
@@ -190,7 +188,6 @@ Tag counts shown are from the markup-fix audit of `mw.txt` (2026-05) — see
 | `<srs/>` | many | Visarga-ligature self-closing marker | `<srs/>` |
 | `{%…%}` | many | Italic span (inline) | `{%also written%}` |
 | `{#…#}` | many | Devanagari / alternate script | `{#कृ#}` |
-{% endraw %}
 
 `<zoo>` is unused in MW (0 occurrences) — zoological names appear inside `<bot>`
 or unmarked prose.
@@ -568,3 +565,4 @@ collection."
 Compound sub-entries in MW are stored as siblings of the parent rather than as
 nested records, with the parent–child relationship implicit in adjacency and
 the `<e>3` hierarchy code.
+{% endraw %}

--- a/papers/microanalysis/DOUBTS.md
+++ b/papers/microanalysis/DOUBTS.md
@@ -1,3 +1,4 @@
+{% raw %}
 # DOUBTS.md — critical review of architecture decisions
 
 **Mandate (2026-05-23):** [@gasyoun](https://github.com/gasyoun) — "Review everything. Doubt everything, all architecture solutions."
@@ -321,3 +322,4 @@ Lumping Cappeller `*` and Benfey `†` as "the precedent" while *omitting* the t
 ### Recording-only notice
 
 Per the O7 prompt mandate, these seven doubts are **recorded, not fixed**. D21 in particular is rated *blocking* because if MW 1872 turns out to have the systematic hedge already, the §7.2(ii) and Appendix C.2 narrative reverses — and the IJL cover letter would need to claim the stronger version of "MW innovation." Resolution work for D16–D22 should be scheduled before submission; recommended order: **D21 first** (it is a 2-hour check that gates the others), then D17 (a footnote), then D16 (a paragraph rewrite), then D18 / D19 / D20 (each ≈ 1 hour of audit and one paragraph of rewrite), then D22 (one table). Total estimated work: 6–10 hours.
+{% endraw %}

--- a/papers/microanalysis/MICROANALYSIS.md
+++ b/papers/microanalysis/MICROANALYSIS.md
@@ -1,3 +1,4 @@
+{% raw %}
 # MW1899 — Microstructural working notes
 
 **Working document.** Exhaustive block-by-block analysis of the Monier-Williams *Sanskrit-English Dictionary* (1899) as digitized in [CDSL `mw.txt`](https://github.com/sanskrit-lexicon/csl-orig/blob/master/v02/mw/mw.txt). This file is the **data source** for the consolidated [paper](PAPER.md) in this directory ([README](README.md)).
@@ -449,3 +450,4 @@ This working notes file *depends on* and *extends* the existing docs-pass conten
 ---
 
 *Last computed: 2026-05-23 against [mw.txt](https://github.com/sanskrit-lexicon/csl-orig/blob/master/v02/mw/mw.txt). Python source: `/tmp/mw_block_matrix.py` in [the docs-pass build artifacts](https://github.com/sanskrit-lexicon/MWS/tree/docs-pass).*
+{% endraw %}

--- a/papers/microanalysis/paper-hausmann.md
+++ b/papers/microanalysis/paper-hausmann.md
@@ -1,3 +1,4 @@
+{% raw %}
 # *Monier-Williams 1899* through the Hausmann–Wiegand comment-class lens
 
 > **Supplementary extended draft — superseded by [PAPER.md](PAPER.md).** One of four single-framework drafts consolidated into the single submission paper per [DOUBTS.md D4](DOUBTS.md#d4--4-framework-papers-from-the-same-data--is-this-honest--blocking). This Hausmann-Wiegand reading (including the proposed *Provenienz-Komment*) is condensed into [PAPER.md Appendix C](PAPER.md#appendix-c--the-hausmann-wiegand-comment-class-reading-condensed); this fuller draft is retained as supplementary material only. **For the canonical paper, read [PAPER.md](PAPER.md).**
@@ -205,3 +206,4 @@ The most consequential MW-specific contribution to scholarly lexicography is the
 ---
 
 *Source data: [MICROANALYSIS.md](MICROANALYSIS.md). Companion framework papers: [Wiegand](paper-wiegand.md) · [Atkins-Rundell](paper-atkins-rundell.md) · [Grounded](paper-grounded.md). All four analyse the same MW1899 dataset through different theoretical lenses.*
+{% endraw %}

--- a/papers/microanalysis/paper-wiegand.md
+++ b/papers/microanalysis/paper-wiegand.md
@@ -1,3 +1,4 @@
+{% raw %}
 # The microstructure of *Monier-Williams 1899*: a Wiegand-theoretic analysis
 
 > **Supplementary extended draft — superseded by [PAPER.md](PAPER.md).** One of four single-framework drafts consolidated into the single submission paper per [DOUBTS.md D4](DOUBTS.md#d4--4-framework-papers-from-the-same-data--is-this-honest--blocking). This Wiegand-theoretic reading is condensed into [PAPER.md Appendix A](PAPER.md#appendix-a--the-wiegand-theoretic-reading-condensed); this fuller draft is retained as supplementary material only. **For the canonical paper, read [PAPER.md](PAPER.md).**
@@ -215,3 +216,4 @@ The digital edition's XML markup makes the analysis tractable for the first time
 ---
 
 *Source data: [MICROANALYSIS.md](MICROANALYSIS.md). Companion framework papers: [Atkins-Rundell](paper-atkins-rundell.md) · [Hausmann-Wiegand](paper-hausmann.md) · [Grounded](paper-grounded.md). All four analyse the same MW1899 dataset through different theoretical lenses.*
+{% endraw %}


### PR DESCRIPTION
## Context

Follow-up to [#198](https://github.com/sanskrit-lexicon/MWS/pull/198) and [#200](https://github.com/sanskrit-lexicon/MWS/pull/200). Those PRs fixed the `{%…%}` italic-span markers. Run [26559039503](https://github.com/sanskrit-lexicon/MWS/actions/runs/26559039503) confirmed `DATA_DICTIONARY.md`, `DICT_PROFILE.md`, and `ENTRY_GUIDE.md` now render cleanly — and surfaced a **second Liquid class** blocking the build:

```
Rendering: papers/microanalysis/DOUBTS.md
Liquid Exception: Liquid syntax error (line 75): Variable '{{' was not properly terminated with regexp: /\}\}/
```

The CDSL correction-record format — `{{old text -> new text || YYYY-MM-DD | author | URL |}}` — uses literal `{{ … }}` which Liquid parses as variable interpolation.

## Audit (master)

Repo-wide grep for `{{…}}` patterns turned up 7 files:

| File | Status before this PR |
|---|---|
| [papers/microanalysis/DOUBTS.md](papers/microanalysis/DOUBTS.md) | **Fatal** at line 75 |
| [papers/microanalysis/MICROANALYSIS.md](papers/microanalysis/MICROANALYSIS.md) | Liquid warning |
| [papers/microanalysis/paper-hausmann.md](papers/microanalysis/paper-hausmann.md) | Liquid warning |
| [papers/microanalysis/paper-wiegand.md](papers/microanalysis/paper-wiegand.md) | Liquid warning |
| [CONTRIBUTING.md](CONTRIBUTING.md) | Liquid warning |
| [DATA_DICTIONARY.md](DATA_DICTIONARY.md) | Warning at line 77 (outside #198's raw block) |
| [ENTRY_GUIDE.md](ENTRY_GUIDE.md) | Warnings at lines 166, 476 (outside #200's raw blocks) |

## Fix

Whole-file `{% raw %} … {% endraw %}` wrap. These are documentation pages, not Jekyll templates — verified via `grep` that **none** of them use intentional Liquid (no `{% include %}`, `{% if %}`, `{{ site.\* }}`, etc.). One wrap kills both the `{%…%}` and `{{…}}` classes at once and is robust against future content additions that re-use the same markup conventions.

For DATA_DICTIONARY.md and ENTRY_GUIDE.md, the inner per-table raw blocks from #198 / #200 are removed and replaced by the whole-file wrap. **Nested raw blocks are not legal in Liquid** — the first `{% endraw %}` closes the outer block, exposing the rest of the file again — so the inner ones must come out.

Untouched: `DICT_PROFILE.md`, `LS_HEDGE_CHECK.md`, `CROSS_DICT.md` keep their inner-region wraps from #200. They contain only `{%…%}` (no `{{…}}`), so the existing inner wraps already suffice.

## Diff

```
 CONTRIBUTING.md                        | 2 ++
 DATA_DICTIONARY.md                     | 4 ++--
 ENTRY_GUIDE.md                         | 6 ++----
 papers/microanalysis/DOUBTS.md         | 2 ++
 papers/microanalysis/MICROANALYSIS.md  | 2 ++
 papers/microanalysis/paper-hausmann.md | 2 ++
 papers/microanalysis/paper-wiegand.md  | 2 ++
 7 files changed, 14 insertions(+), 6 deletions(-)
```

Rendered HTML is identical — the wrapper tags are consumed by Liquid before output.

## Verification

Once merged, the Pages workflow re-runs against master. Expected: `success` on the next run, with site re-deployed. If a further Liquid issue appears in a file my grep missed, it'll be a separate root cause and easy to add to this pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)