### PR TITLE
Silence remaining Liquid warning + document the gotcha in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,6 +96,25 @@ If the source file (`mw.txt`) itself records the correction history, the format 
 These records are preserved verbatim and processed by the `updateByLine.py`
 toolchain — never edit them by hand.
 
+### GitHub Pages / Jekyll Liquid gotcha
+
+GitHub Pages renders this repo's Markdown through Jekyll. Jekyll's Liquid
+templating engine treats two CDSL markup conventions as template syntax:
+
+- `{%…%}` — the italic-span marker; collides with Liquid tag syntax.
+- `{{…}}` — the correction-record format above; collides with Liquid
+  variable interpolation.
+
+A page containing either marker outside an escape block breaks the Pages
+build. The fix applied across this repo is to wrap the entire affected
+file in `{% raw %}` and the matching closing tag. See
+[DATA_DICTIONARY.md](DATA_DICTIONARY.md), [ENTRY_GUIDE.md](ENTRY_GUIDE.md),
+[DICT_PROFILE.md](DICT_PROFILE.md) and the `papers/microanalysis/` notes
+for working examples (PRs [#198](https://github.com/sanskrit-lexicon/MWS/pull/198), [#200](https://github.com/sanskrit-lexicon/MWS/pull/200), [#201](https://github.com/sanskrit-lexicon/MWS/pull/201)).
+
+When adding a new `.md` documenting `<L>` records, markup conventions, or
+sample entry text — wrap it.
+
 ### Pull request checklist
 
 - [ ] Correction verified against the 1899 print facsimile

--- a/mwsissues/issue178/rev1a/change_notes_rev1a.txt
+++ b/mwsissues/issue178/rev1a/change_notes_rev1a.txt
@@ -2,6 +2,7 @@
 old: <L>61958.1<pc>1326,1<k1>khilyá<k2>khilyá<e>1
 new: <L>61958.1<pc>1326,1<k1>khilya<k2>khilyá<e>1
 ---
+{% raw %}
 L=423
 old: <info n=rev_sup"/>
 new: <info n="rev_sup"/>
@@ -63,3 +64,4 @@ L= 103901.2  ->  105839.2
 L= 160542.1  -> 160543.1
 L= 167755.01  ->  167755.2
 L= 235355.1  ->  235354.1
+{% endraw %}


### PR DESCRIPTION
## Context

Two small follow-ups to the Pages-build fix chain ([#198](https://github.com/sanskrit-lexicon/MWS/pull/198), [#200](https://github.com/sanskrit-lexicon/MWS/pull/200), [#201](https://github.com/sanskrit-lexicon/MWS/pull/201)). The build is now passing the Jekyll step on master; this PR closes the two open trailing items:

### 1. Silence remaining warning in `change_notes_rev1a.txt`

Run [26559430276](https://github.com/sanskrit-lexicon/MWS/actions/runs/26559430276) emits these Liquid warnings (non-fatal but logged on every build):

```
Liquid Warning: Liquid syntax error (line 49): Expected end_of_string but found comma in "{{38165.1, 38165.2}}" in mwsissues/issue178/rev1a/change_notes_rev1a.txt
Liquid Warning: Liquid syntax error (line 56): Expected end_of_string but found comma in "{{95074, 95074.1}}"   in mwsissues/issue178/rev1a/change_notes_rev1a.txt
Liquid Warning: Liquid syntax error (line 56): Expected end_of_string but found comma in "{{95074, 95074.05}}"  in mwsissues/issue178/rev1a/change_notes_rev1a.txt
```

The file's leading `---` is a section delimiter in the correction-record format but Jekyll's parser reads it as the start of YAML front-matter, so it gets rendered. Wrapping the body in `{% raw %}` / `{% endraw %}` silences the warnings without disturbing the front-matter boundary.

### 2. Document the gotcha in `CONTRIBUTING.md`

A new subsection — **GitHub Pages / Jekyll Liquid gotcha** — sits right after **In-file correction records** (where the `{{old text -> new text || …}}` syntax is introduced). It explains why `{%…%}` and `{{…}}` collide with Liquid, points readers at [DATA_DICTIONARY.md](DATA_DICTIONARY.md), [ENTRY_GUIDE.md](ENTRY_GUIDE.md), [DICT_PROFILE.md](DICT_PROFILE.md) for working examples, and links #198, #200, #201. The hope is the next contributor adding a new docs page won't have to rediscover the pattern from a failing build.

## Diff

```
 CONTRIBUTING.md                                 | 19 +++++++++++++++++++
 mwsissues/issue178/rev1a/change_notes_rev1a.txt |  2 ++
 2 files changed, 21 insertions(+)
```

## Verification

Pages build should remain green; the warnings from `change_notes_rev1a.txt` should drop out of the log. No behavioural changes elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)