### PR TITLE
Add Semgrep SAST workflow (PHP + Python)

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,0 +1,44 @@
+name: Semgrep
+
+# CodeQL has no PHP analyzer, so the PHP files in this repo get no SAST from it.
+# Semgrep DOES support PHP: this fills that gap (and also covers Python via the
+# security-audit ruleset). Results upload to the repo's Security tab.
+# Non-blocking, like the CodeQL workflow. Mirrors csl-websanlexicon/semgrep.yml.
+
+on:
+  push:
+    branches: [master, main]
+  pull_request:
+    branches: [master, main]
+  schedule:
+    - cron: '0 4 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  semgrep:
+    name: Semgrep SAST
+    runs-on: ubuntu-latest
+    container:
+      image: semgrep/semgrep
+    # The semgrep container ships its own Python; skip on Dependabot (no token).
+    if: github.actor != 'dependabot[bot]'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run Semgrep
+        run: |
+          semgrep scan \
+            --config p/php \
+            --config p/security-audit \
+            --sarif --output semgrep.sarif \
+            --metrics off || true
+
+      - name: Upload SARIF to Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: semgrep.sarif


### PR DESCRIPTION
## What

Adds a non-blocking **Semgrep SAST** workflow (`.github/workflows/semgrep.yml`), mirroring the one in [csl-websanlexicon](https://github.com/sanskrit-lexicon/csl-websanlexicon/blob/master/.github/workflows/semgrep.yml).

## Why

CodeQL has **no PHP analyzer**, so the PHP files in this repo currently get no static analysis (the `Analyze (php)` CodeQL job was removed earlier for exactly that reason). Semgrep supports PHP and fills that gap; the `p/security-audit` ruleset also adds Python coverage. Results upload to the **Security** tab; the job is non-blocking and runs on push/PR + weekly.

First run will surface any findings to triage (this repo's PHP footprint is small, so expect a short list).

🤖 Generated with [Claude Code](https://claude.com/claude-code)