### PR TITLE
Escape $_GET reflections in list02php (reflected-XSS)

### DIFF
--- a/list02php/index.php
+++ b/list02php/index.php
@@ -157,12 +157,12 @@ $("#key").autocomplete({
  };
  phpinit = function() {
   var names = ['key','dict','input','output','accent'];
-  var phpvals=[ // same order as names
-  "<?php echo $_GET['key']?>",
-  "<?php echo $_GET['dict']?>",
-  "<?php echo $_GET['input']?>",
-  "<?php echo $_GET['output']?>",
-  "<?php echo $_GET['accent']?>"];
+  var phpvals=[ // same order as names; json_encode yields a safe quoted JS string
+  <?php echo json_encode(isset($_GET['key'])&&is_string($_GET['key'])?$_GET['key']:'', JSON_HEX_TAG|JSON_HEX_AMP|JSON_HEX_APOS|JSON_HEX_QUOT) ?>,
+  <?php echo json_encode(isset($_GET['dict'])&&is_string($_GET['dict'])?$_GET['dict']:'', JSON_HEX_TAG|JSON_HEX_AMP|JSON_HEX_APOS|JSON_HEX_QUOT) ?>,
+  <?php echo json_encode(isset($_GET['input'])&&is_string($_GET['input'])?$_GET['input']:'', JSON_HEX_TAG|JSON_HEX_AMP|JSON_HEX_APOS|JSON_HEX_QUOT) ?>,
+  <?php echo json_encode(isset($_GET['output'])&&is_string($_GET['output'])?$_GET['output']:'', JSON_HEX_TAG|JSON_HEX_AMP|JSON_HEX_APOS|JSON_HEX_QUOT) ?>,
+  <?php echo json_encode(isset($_GET['accent'])&&is_string($_GET['accent'])?$_GET['accent']:'', JSON_HEX_TAG|JSON_HEX_AMP|JSON_HEX_APOS|JSON_HEX_QUOT) ?>];
   var i,name,phpval;
   for(i=0;i<names.length;i++) {
    phpinit_helper(names[i],phpvals[i]);


### PR DESCRIPTION
## What

Replaces raw `"<?php echo $_GET['key']?>"` reflections in the JS of `list02php/index.php` with `json_encode(...)`.

## Why

The five `$_GET` values (`key`, `dict`, `input`, `output`, `accent`) were echoed unescaped into a JavaScript string array inside a `<script>` block — a reflected-XSS (e.g. `?key=\"];alert(1)//` breaks out of the JS string). `json_encode` emits a properly-quoted, escaped JS string literal; the `JSON_HEX_*` flags also neutralise `</script>` / quote breakouts, and the `is_string` guard avoids array-injection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)