### PR TITLE
Escape $_GET reflections in list02php/index.php via json_encode (reflected-XSS)

### DIFF
--- a/list02php/index.php
+++ b/list02php/index.php
@@ -158,11 +158,16 @@ $("#key").autocomplete({
  phpinit = function() {
   var names = ['key','dict','input','output','accent'];
   var phpvals=[ // same order as names
-  "<?php echo $_GET['key']?>",
-  "<?php echo $_GET['dict']?>",
-  "<?php echo $_GET['input']?>",
-  "<?php echo $_GET['output']?>",
-  "<?php echo $_GET['accent']?>"];
+  // json_encode emits a fully-quoted, escaped JS string literal, so attacker
+  // controlled GET values can no longer break out of the string / <script>
+  // block (reflected-XSS). The surrounding quotes are intentionally gone:
+  // json_encode supplies them. '?? ' keeps the empty-when-absent behavior and
+  // avoids PHP 8 undefined-array-key warnings.
+  <?php echo json_encode($_GET['key']    ?? '') ?>,
+  <?php echo json_encode($_GET['dict']   ?? '') ?>,
+  <?php echo json_encode($_GET['input']  ?? '') ?>,
+  <?php echo json_encode($_GET['output'] ?? '') ?>,
+  <?php echo json_encode($_GET['accent'] ?? '') ?>];
   var i,name,phpval;
   for(i=0;i<names.length;i++) {
    phpinit_helper(names[i],phpvals[i]);


### PR DESCRIPTION
## Summary

Second-pass security cleanup. [`list02php/index.php`](https://github.com/sanskrit-lexicon/MWS/blob/security/list02php-reflected-xss/list02php/index.php)'s `phpinit()` emitted five `$_GET` parameters **raw** into a JavaScript string array (was lines 161–165):

```php
var phpvals=[ // same order as names
"<?php echo $_GET['key']?>",
"<?php echo $_GET['dict']?>",
...
```

This is a real reflected-XSS sink: an attacker can break out of the JS string and `<script>` block, e.g.

```
?key="];alert(1)//
```

`list02php` is a hand-maintained standalone app (see [`list02php/readme.md`](https://github.com/sanskrit-lexicon/MWS/blob/master/list02php/readme.md) — "install this in a php web server … point the browser to index.php"), **not** generated from the `csl-websanlexicon` makotemplates, so the fix is applied directly here.

## Fix

Wrap each value in `json_encode()`, which emits a fully-quoted, escaped JS string literal (the surrounding manual quotes are removed — `json_encode` supplies them):

```php
<?php echo json_encode($_GET['key'] ?? '') ?>,
```

- The breakout `"` is escaped; `/` becomes `\/`, so a `</script>` sequence can't be formed either.
- `?? ''` preserves the existing empty-string-when-absent behavior and avoids PHP 8 undefined-array-key warnings.

Same vulnerability class and fix idiom as the JSONP callback hardening in [`csl-websanlexicon`](https://github.com/sanskrit-lexicon/csl-websanlexicon) — issue [csl-websanlexicon#27](https://github.com/sanskrit-lexicon/csl-websanlexicon/issues/27) / PRs [#63](https://github.com/sanskrit-lexicon/csl-websanlexicon/pull/63), [#67](https://github.com/sanskrit-lexicon/csl-websanlexicon/pull/67).

## Verification

- `php -l` clean (PHP 8.2).
- `json_encode('"];alert(1)//')` → `"\"];alert(1)\/\/"` (breakout neutralized); `json_encode('</script>…')` → `"<\/script>…"` (tag broken); unset → `""` (behavior preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)