### PR TITLE
H1077 delta: 2013 supplementary-volume editors fix (Wiegand & Smit -> Gouws et al.) + dossier §6

### DIFF
--- a/papers/microanalysis/PAPER.md
+++ b/papers/microanalysis/PAPER.md
@@ -251,7 +251,7 @@ Triangulated against three external traditions, the grounded reading is corrobor
 
 ## Appendix A — The Wiegand-theoretic reading (condensed)
 
-**Framing:** Wiegand's microstructure theory (1989a, 1989b, 1996a, 1996b, 2002; Wiegand & Smit 2013). An XML markup language *is*, in Wiegand's terms, a system of **structural indicators** (*Strukturanzeiger*) — each tag a typographically-distinct signal of an item-class (*Angabeklasse*).
+**Framing:** Wiegand's microstructure theory (1989a, 1989b, 1996a, 1996b, 2002; Gouws et al. 2013). An XML markup language *is*, in Wiegand's terms, a system of **structural indicators** (*Strukturanzeiger*) — each tag a typographically-distinct signal of an item-class (*Angabeklasse*).
 
 **A.1 — Microstructure type.** Wiegand distinguishes *integrated* from *non-integrated* (purely additive) microstructures, with partially integrated subtypes (1989b: 462–501); the *semi-integrated* label is his later refinement (1996b: 1–82). **MW is fully integrated at the macro level and additive at the micro level for thin entries.** The `<e>1` → `<e>1A` → `<e>2` → `<e>3` hierarchy ([data](../../ENTRY_GUIDE.md#entry-hierarchy-distribution)) realises a 4-deep integration; the `<e>1A` continuation — a sub-article whose lemma is suppressed (33.9% retain `<s>`) and whose existence is intelligible only relative to the preceding `<e>1` — is the archetypal integrated-microstructure marker. Two caveats keep MW from maximal integration: (i) `<e>1A` continuations are formally *separate* `<L>` records rather than nested under their parent, integrated only by adjacency and the `<e>1A` indicator (**adjacency-integration**); (ii) lexicographer-only entries are often internally *additive* (one sense + one `<ls>L.</ls>`).
 
@@ -334,7 +334,7 @@ MW 1899's *structural* innovation — promoting the hedge from a typographic mar
 - Wiegand, H. E. (1996a). *Über die Mediostrukturen bei gedruckten Wörterbüchern*. In A. Zettersten & V. H. Pedersen (eds.), *Symposium on Lexicography VII* (Lexicographica Series Maior 76). Tübingen: Niemeyer, 11–43.
 - Wiegand, H. E. (1996b). *Das Konzept der semiintegrierten Mikrostrukturen: Ein Beitrag zur Theorie zweisprachiger Printwörterbücher*. In H. E. Wiegand (ed.), *Wörterbücher in der Diskussion II*. Tübingen: Niemeyer, 1–82.
 - Wiegand, H. E. (2002). *Equivalence in Bilingual Lexicography: Criticism and Suggestions*. Lexikos 12: 239–255. DOI [10.5788/12-0-772](https://doi.org/10.5788/12-0-772).
-- Wiegand, H. E. & Smit, M. (eds.) (2013). *Dictionaries: An International Encyclopedia of Lexicography*. Supplementary Volume. De Gruyter.
+- Gouws, R. H., Heid, U., Schweickard, W. & Wiegand, H. E. (eds.) (2013). *Dictionaries. An International Encyclopedia of Lexicography. Supplementary Volume: Recent Developments with Focus on Electronic and Computational Lexicography* (HSK 5.4). Berlin/Boston: De Gruyter Mouton.
 
 ---
 

--- a/papers/microanalysis/SIGNOFF_A16_citation_dossier.md
+++ b/papers/microanalysis/SIGNOFF_A16_citation_dossier.md
@@ -135,6 +135,34 @@ the dictionary" 160–199 · Ch. 7 "Planning the entry" 200–259 · Ch. 8 "Word
 
 ---
 
+## 6 · Wiegand & Smit (eds.) 2013 — verdict: **WRONG-EDITORS, corrected** (second-pass catch)
+
+An independent second verification pass (same session series, H1077; four parallel web
+agents re-auditing the whole reference list to the Major-5 standard) caught one defect the
+first pass left in place: the reference "Wiegand, H. E. & Smit, M. (eds.) (2013).
+*Dictionaries: An International Encyclopedia of Lexicography*. Supplementary Volume. De
+Gruyter" has the **wrong editors**. The volume is HSK 5.4 and its editors are **Gouws,
+Heid, Schweickard & Wiegand** — there is no editor named Smit (Maria Smit is a Wiegand
+translator/co-author on other works). Evidence, three independent records quoting the
+full editor list verbatim:
+
+- [ZrP 2014 review](https://www.degruyterbrill.com/document/doi/10.1515/zrp-2014-0114/html?lang=en): "Rufus Gouws / Ulrich Heid / Wolfgang Schweickard / Herbert Ernst Wiegand (edd.), Dictionaries. An International Encyclopedia of Lexicography. Supplementary volume … (HSK, 5.4), Berlin/Boston, De Gruyter Mouton, 2013, 1579 p."
+- [Springer *Lexicography* review](https://link.springer.com/article/10.1007/s40607-015-0013-8): "Rufus H. Gouws, Ulrich Heid, Wolfgang Schweickard and Herbert Ernst Wiegand (eds.) … (HSK Vol. 5.4). Berlin: De Gruyter Mouton, 2013. XIII + 1,579 pp. ISBN 978-3-11-023812-9"
+- [Project MUSE review](https://muse.jhu.edu/article/604749/pdf): "ed. by Rufus Gouws et al."
+
+**Applied to PAPER.md (vetoable):** reference entry replaced with the Gouws/Heid/
+Schweickard/Wiegand form (HSK 5.4, Berlin/Boston: De Gruyter Mouton); the Appendix A
+framing cite "Wiegand & Smit 2013" → "Gouws et al. 2013".
+
+The same second pass independently re-derived and **confirmed** the §1–§3 verdicts above
+(Schreyer phantom + Vogel 1979 as the real survey; Hausmann 1985 → *Handbuch der
+Lexikologie* 367–411; 416–425 falling in the Mikrostruktur concept article, not the
+Makrostruktur one; the Wiegand 1995 Popp-Festschrift referent with the 8–12 figure
+unconfirmable) — two blind agent passes agreeing is itself sign-off evidence. For §5
+(A&R) the second pass, working TOC-only from the [Library of Congress page-numbered
+TOC](https://catdir.loc.gov/catdir/toc/ecip0816/2008016902.html), flagged p. 199 as its
+strongest fabrication candidate — converging with §5's full-text MISMATCH finding.
+
 ## Residual observations (not applied — noted for the author)
 
 1. Appendix C's framing attributes the *Kommentare* sequence to "Hausmann (1977, 1985)";


### PR DESCRIPTION
Follow-up to #244 (H1077 citation pre-verification dossier). An independent second verification pass over the full reference list caught one defect the merged pass left in place: **"Wiegand, H. E. & Smit, M. (eds.) (2013)" has the wrong editors** — the volume is HSK 5.4, edited by **Gouws, Heid, Schweickard & Wiegand** (no editor named Smit).

Evidence (verbatim editor lists): [ZrP 2014 review](https://www.degruyterbrill.com/document/doi/10.1515/zrp-2014-0114/html?lang=en) · [Springer *Lexicography* review](https://link.springer.com/article/10.1007/s40607-015-0013-8) · [Project MUSE](https://muse.jhu.edu/article/604749/pdf).

Changes:
- [PAPER.md](https://github.com/sanskrit-lexicon/MWS/blob/docs-pass/papers/microanalysis/PAPER.md): reference entry replaced with the Gouws/Heid/Schweickard/Wiegand HSK 5.4 form; Appendix A framing cite "Wiegand & Smit 2013" -> "Gouws et al. 2013".
- [SIGNOFF_A16_citation_dossier.md](https://github.com/sanskrit-lexicon/MWS/blob/docs-pass/papers/microanalysis/SIGNOFF_A16_citation_dossier.md): new §6 documenting the catch + the note that the second pass independently confirmed §1–§3 verdicts and converged on the §5 p. 199 MISMATCH.

`check_docs.py` green (639 links, 45 files).

Handoff: [H1077](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1077-Fable_MWS_a16-major5-citation-preverify-dossier_16.07.26.md) · Executor: Fable 5 (`claude-fable-5`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
