### PR TITLE
ai-wip: journal the A18 draft (H1076) + mw.txt record drift

### DIFF
--- a/.ai_state.md
+++ b/.ai_state.md
@@ -1,6 +1,6 @@
 # Project Objective: Execute the 2026 H2 roadmap (ROADMAP.md, rewritten 2026-06-12)
 
-_Created: 08-05-2026 · Last updated: 03-07-2026_
+_Created: 08-05-2026 · Last updated: 16-07-2026_
 
 Four workstreams: W1 authority records (589 orphans), W2 P1 paper → IJL,
 W3 Salt API MW pilot, W4 MW-as-template for other dicts. Tiered model policy:
@@ -37,6 +37,14 @@ start commands in the GTD agent row:
 - [ ] #217 adjudication comment posted 02-07 — awaiting @funderburkjim/@Andhrabharati reaction (unblocks SPEC-5 §1)
 
 ## 🧠 Dev Notes & Hypotheses
+
+- 2026-07-16: **`mw.txt` drift + a numbering caution** (Fable 5 `claude-fable-5`, H1076). The census
+  reads **286,525** records against the **286,560** logged 2026-06-13 (over `mw.txt` @ 2026-05-29) —
+  35 records lost to upstream corrections in ~1 month; csl-atlas' artifact independently reports
+  286,525, so the source moved, not the parse. Also: this census classes a citation by its **siglum**,
+  so the two meta-with-locator anomalies in all of MW (`<ls>L. i</ls>`, `<ls>W. 1</ls>`) sit in
+  hedge/authority — the strata run +1/+1 against the literal-match counts (40,212 / 19,297). Recorded
+  so a later session does not read either as drift.
 
 - 2026-07-03: **G5 adjudication rulings worth remembering** (Fable 5 `claude-fable-5`, H070) —
   the governing line for gold decisions: the paper's [MICROANALYSIS.md §1](https://github.com/sanskrit-lexicon/MWS/blob/docs-pass/papers/microanalysis/MICROANALYSIS.md)
@@ -134,6 +142,42 @@ start commands in the GTD agent row:
 - Monthly cadence assumes 1 Fable planning session + ~4 Sonnet sessions/month.
 
 ## ✅ Completed (Recent only)
+
+- [x] 2026-07-16: **A18 drafted 2/5→3/5 — full Dictionaries-2027 manuscript + register census**
+  (Fable 5 `claude-fable-5`, [H1076](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1076-Fable_MWS_a18-citation-registers-draft_16.07.26.md),
+  [PR #246](https://github.com/sanskrit-lexicon/MWS/pull/246) merged).
+  [A18_citation_registers_paper.md](https://github.com/sanskrit-lexicon/MWS/blob/master/papers/p3_citation_registers/A18_citation_registers_paper.md) «One Slot, Many
+  Warrants» + new deterministic [register_census/](https://github.com/sanskrit-lexicon/MWS/blob/master/papers/p3_citation_registers/register_census/).
+  **Method alignment first** (the handoff's gate): A08's (csl-atlas) Register A/B terminology consumed
+  **unchanged, not forked**; the paper extends it on the axis form cannot see — *evidentiary status
+  inside Register A*. MW's standing as a Register-A dict is confirmed, not assumed (250 `iti` hits,
+  0.001/entry). **Census:** all **320,828** tagged citations (not 312,160 — see below) → 5 strata:
+  attested **18.96%** · bare **59.35%** · hedge **12.53%** · authority **6.02%** · relative **3.15%**;
+  38,538 records rest on the hedge alone. **Core argument:** `<ls>L.</ls>` is Register-B *kośa content*
+  in a Register-A *slot* with the source name deleted — where the two registers, treated as disjoint
+  dictionary populations, meet inside one entry.
+  **Two propagated measurement errors corrected, both flattering the apparatus:**
+  (1) **MW's scan-link ceiling was overstated ~2×.** `ROADMAP.md` (status table, §W1, weaknesses row 2)
+  + `SYNTHESIS.md` gave "22.3% meta + **40.2%** bare-locator" ⇒ ~37.5% linkable. The 40.2% was **never
+  an MW measurement**: it is the corpus-wide CDSL bare share from a *superseded 43-dict* revision of
+  A08's table (dominated by PWG at 4.61 `<ls>`/entry vs MW's 1.09), and the two components were computed
+  over different populations — never additively coherent. MW's own locator share is **18.96%**. Fixed in
+  place with dated notes. (2) **csl-atlas' MW row undercounts 28.6%** — literal `_LS` regex misses MW's
+  8,668 attributed-shape citations (`<ls n="RV.">vii, 96, 3</ls>`); `\d` locator rule misses 4,866
+  roman-only locators (`ŚBr. xiv`). Both its published figures reproduce **exactly** under its own rule,
+  localising the cause to markup shape. Regeneration queued →
+  [H1086](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1086-Sonnet_csl-atlas_mw-row-regenerate-ls-shapes_17.07.26.md)
+  (corpus-wide). Logged as [SanskritLexicography FINDINGS §89](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md)
+  ([PR #508](https://github.com/gasyoun/SanskritLexicography/pull/508) merged).
+  **Verification earned its keep again:** 2 adversarial + 1 fact-check pass caught **14** defects
+  pre-commit — incl. "every twelfth citation" where the census says one in **eight**; an `ib.` claim
+  conflating confidence (57.1% same-cluster) with terminal-type (74.7% real-source), two orthogonal
+  splits; an unsupported "2.5×"; a naive `id.` substring count that swept in `Kālid.` (a siglum that
+  *does* occur inside `<ls>`); and **the census's own case-folding bug** — lowercasing made the hedge
+  `L.` read as roman 50 and `Vi.` as roman 6, reclassifying ~46,000 citations and zeroing the hedge
+  stratum, caught only because `<ls>L.</ls>` = 40,212 was independently known. Run is deterministic;
+  the attested stratum's decomposition is pinned by an `assert` (which caught a further off-by-one).
+  **Open gate:** author sign-off (4 gates in the draft's status block) — GTD `@DO`.
 
 - [x] 2026-07-03: **ZettelkastenWiki pilot #4 — defaults-layer probe** (Sonnet 5
   `claude-sonnet-5`). Measured real frontmatter-less MWS reader docs: bare


### PR DESCRIPTION
Journals the A18 draft ([H1076](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1076-Fable_MWS_a18-citation-registers-draft_16.07.26.md), [PR #246](https://github.com/sanskrit-lexicon/MWS/pull/246)) into `.ai_state.md`. Model: **Fable 5** (`claude-fable-5`).

- **Completed:** A18 2/5→3/5, the register census (320,828 citations → 5 evidentiary strata), the two corrected propagated errors (MW's ~2×-overstated scan-link ceiling; csl-atlas' 28.6% MW-row undercount → H1086), and the 14 defects the 2 adversarial + 1 fact-check passes caught pre-commit.
- **Dev note — source drift:** `mw.txt` now reads **286,525** records against the **286,560** logged 2026-06-13 (−35 to upstream corrections in ~1 month). csl-atlas' artifact independently reports 286,525, so the *source* moved, not the parse. Also records the +1/+1 siglum-first delta against the literal-match counts (the two `<ls>L. i</ls>` / `<ls>W. 1</ls>` anomalies in all of MW), so a later session does not read either as drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
