### PR TITLE
fix(security): bump demo jQuery 2.1.4 → 3.7.1 (H1523)

### DIFF
--- a/basic04a/index.html
+++ b/basic04a/index.html
@@ -7,7 +7,7 @@
 <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.11.4/jquery-ui.min.css">
 
 <!-- links to jquery, using CDNs -->
-<script type="text/javascript" src="http://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script type="text/javascript" src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
 
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery-cookie/1.4.1/jquery.cookie.min.js"></script>
 <!-- jquery-ui is used -->

--- a/list02php/index.php
+++ b/list02php/index.php
@@ -19,7 +19,7 @@ error_reporting(E_ALL & ~E_NOTICE);
 <title>list-0.2 Cologne</title>
 <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.11.4/jquery-ui.min.css">
 <!-- links to jquery, using CDNs -->
-<script type="text/javascript" src="http://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script type="text/javascript" src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
 
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery-cookie/1.4.1/jquery.cookie.min.js"></script>
 <!-- jquery-ui is used -->


### PR DESCRIPTION
## Summary
`list02php/index.php` and `basic04a/index.html` still loaded **jQuery 2.1.4 over plain HTTP**. XSS CVEs fixed in jQuery 3.4+; H1523 already bumped csl-apidev / csl-websanlexicon to 3.7.1 — these MWS demo pages were residual.

## Fix
- CDN: `http://code.jquery.com/jquery-2.1.4.min.js` → `https://code.jquery.com/jquery-3.7.1.min.js`
- Files: `list02php/index.php`, `basic04a/index.html`
- Left `jquery.cookie` / jquery-ui as-is (cookie stack migration is separate; these demos still call `$.cookie`)

H1523 org bug-hunt.