### PR TITLE
fix(cookies): migrate demos jquery.cookie → js-cookie (H1523)

### DIFF
--- a/basic04a/cookieUpdate.js
+++ b/basic04a/cookieUpdate.js
@@ -1,31 +1,31 @@
-/* Uses jQuery.cookie */
+/* Uses js-cookie (Cookies global) — H1523 migrate from jquery.cookie */
 CologneDisplays.dictionaries.cookieUpdate = function(flag) {
  // Cookie for holding input, output, accent, dict1 values;
  // When flag is true, update cookies from corresponding dom values
  // When flag is false, initialize dom values from cookie values,
  //  but use default values if cookie values not present.
-    var cookieNames = ['input','output','accent','dict1','dict2'];
+ var cookieNames = ['input','output','accent','dict1','dict2'];
  var domids = ['#input','#output','#accent','#dict1','#dict2'];
- var cookieOptions = {expires: 365, path:'/'}; // 365 days
+ var cookieOptions = {expires: 365, path:'/', sameSite: 'Lax'}; // 365 days
  var i,cookieName,cookieValue,domid;
  if (flag) { // set values of cookies acc. to 'value' of corresponding ids
   for(i=0;i<cookieNames.length;i++) {
    cookieName=cookieNames[i];
    domid=domids[i];
    cookieValue=$(domid).val();
-   $.cookie(cookieName,cookieValue,cookieOptions);
+   Cookies.set(cookieName, cookieValue, cookieOptions);
   }
   return;
  }
  // When flag is false. For initializing (a) cookies, and (b) dom values
-    var cookieDefaultValues = ['hk','deva','no','mw','mw'];
+ var cookieDefaultValues = ['hk','deva','no','mw','mw'];
  for(i=0;i<cookieNames.length;i++) {
   cookieName=cookieNames[i];
   domid=domids[i];
-  cookieValue = $.cookie(cookieName); // old value of cookie
-  if(! cookieValue) { // cookie not defined. 
+  cookieValue = Cookies.get(cookieName); // old value of cookie
+  if(! cookieValue) { // cookie not defined.
    cookieValue= cookieDefaultValues[i]; // Use default value
-   $.cookie(cookieName,cookieValue,cookieOptions); // and set cook
+   Cookies.set(cookieName, cookieValue, cookieOptions); // and set cook
   }
   // set dom value
   $(domid).val(cookieValue);

--- a/basic04a/index.html
+++ b/basic04a/index.html
@@ -9,7 +9,7 @@
 <!-- links to jquery, using CDNs -->
 <script type="text/javascript" src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
 
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery-cookie/1.4.1/jquery.cookie.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/js-cookie/3.0.5/js.cookie.min.js"></script>
 <!-- jquery-ui is used -->
 
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.11.4/jquery-ui.min.js"></script>

--- a/list02php/cookieUpdate.js
+++ b/list02php/cookieUpdate.js
@@ -1,4 +1,4 @@
-/* Uses jQuery.cookie */
+/* Uses js-cookie (Cookies global) — H1523 migrate from jquery.cookie */
 CologneDisplays.dictionaries.cookieUpdate = function(flag) {
  // Cookie for holding input, output, accent, dict values;
  // When flag is true, update cookies from corresponding dom values
@@ -6,26 +6,33 @@ CologneDisplays.dictionaries.cookieUpdate = function(flag) {
  //  but use default values if cookie values not present.
  var cookieNames = ['input','output','accent','dict'];
  var domids = ['#input','#output','#accent','#dict'];
- var cookieOptions = {expires: 365, path:'/'}; // 365 days
+ var cookieOptions = {expires: 365, path:'/', sameSite: 'Lax'}; // 365 days
  var i,cookieName,cookieValue,domid;
+ var cookieDefaultValues = ['hk','deva','no','mw'];
  if (flag) { // set values of cookies acc. to 'value' of corresponding ids
   for(i=0;i<cookieNames.length;i++) {
    cookieName=cookieNames[i];
    domid=domids[i];
    cookieValue=$(domid).val();
-   $.cookie(cookieName,cookieValue,cookieOptions);
+   if ((cookieValue === undefined) || (cookieValue === 'null') || (cookieValue === null) || (cookieValue === '')) {
+    cookieValue = cookieDefaultValues[i];
+    Cookies.set(cookieName, cookieValue, cookieOptions);
+    $(domid).val(cookieValue);
+   } else {
+    Cookies.set(cookieName, cookieValue, cookieOptions);
+   }
   }
   return;
  }
  // When flag is false. For initializing (a) cookies, and (b) dom values
- var cookieDefaultValues = ['hk','deva','no','mw'];
  for(i=0;i<cookieNames.length;i++) {
   cookieName=cookieNames[i];
   domid=domids[i];
-  cookieValue = $.cookie(cookieName); // old value of cookie
-  if(! cookieValue) { // cookie not defined. 
+  cookieValue = Cookies.get(cookieName); // old value of cookie
+  // When not defined, cookieValue may be string 'null', not JS null.
+  if ((cookieValue === undefined) || (cookieValue === 'null') || (cookieValue === null) || (cookieValue === '')) {
    cookieValue= cookieDefaultValues[i]; // Use default value
-   $.cookie(cookieName,cookieValue,cookieOptions); // and set cook
+   Cookies.set(cookieName, cookieValue, cookieOptions); // and set cook
   }
   // set dom value
   $(domid).val(cookieValue);

--- a/list02php/index.php
+++ b/list02php/index.php
@@ -21,11 +21,12 @@ error_reporting(E_ALL & ~E_NOTICE);
 <!-- links to jquery, using CDNs -->
 <script type="text/javascript" src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
 
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery-cookie/1.4.1/jquery.cookie.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/js-cookie/3.0.5/js.cookie.min.js"></script>
 <!-- jquery-ui is used -->
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.11.4/jquery-ui.min.js"></script>
-<script type="text/javascript" src="http://www.sanskrit-lexicon.uni-koeln.de/scans/awork/apidev/sample/dictnames.js"></script>
-<script type="text/javascript" src="http://www.sanskrit-lexicon.uni-koeln.de/scans/awork/apidev/sample/cookieUpdate.js"></script>
+<script type="text/javascript" src="https://www.sanskrit-lexicon.uni-koeln.de/scans/awork/apidev/sample/dictnames.js"></script>
+<!-- Local cookieUpdate (js-cookie API); avoids depending on server deploy of sample/ -->
+<script type="text/javascript" src="cookieUpdate.js"></script>
 
 <style>
 body {


### PR DESCRIPTION
## Summary
After the jQuery 3.7.1 bump ([#259](https://github.com/sanskrit-lexicon/MWS/pull/259)), demos still loaded **jquery.cookie 1.4.1**. Production stacks (csl-websanlexicon, csl-apidev samples) already use **js-cookie**.

## Fix
- CDN: `jquery-cookie/1.4.1` → `js-cookie/3.0.5`
- `cookieUpdate.js` in `list02php/` + `basic04a/`: `$.cookie` → `Cookies.get` / `Cookies.set` (+ `sameSite: 'Lax'`)
- `list02php/index.php`: load **local** `cookieUpdate.js` (was remote HTTP Cologne sample); `dictnames.js` URL → HTTPS

H1523 org bug-hunt.