### PR TITLE
docs: fix stale roadmap/ai_state drift (H1877)

### DIFF
--- a/.ai_state.md
+++ b/.ai_state.md
@@ -1,6 +1,6 @@
 # Project Objective: Execute the 2026 H2 roadmap (ROADMAP.md, rewritten 2026-06-12)
 
-_Created: 08-05-2026 · Last updated: 28-07-2026_
+_Created: 08-05-2026 · Last updated: 29-07-2026_
 
 Four workstreams: W1 authority records (589 orphans), W2 P1 paper → IJL,
 W3 Salt API MW pilot, W4 MW-as-template for other dicts. Tiered model policy:
@@ -24,9 +24,12 @@ start commands in the GTD agent row:
 - [x] SPEC-3: C-SALT parity report + Phase-2 closeout in csl-apidev ([SPEC-3](https://github.com/sanskrit-lexicon/MWS/blob/master/planning/specs/2026-07/SPEC-3-salt-parity.md)) — **✅ done 08-07-2026** (Sonnet 5 `claude-sonnet-5`, [csl-apidev PR pending](https://github.com/sanskrit-lexicon/csl-apidev)): first run-verification of the Salt API against real data (`mw.sqlite` fetched from [csl-sqlite](https://github.com/sanskrit-lexicon/csl-sqlite) release) — found + fixed a real bug (`Parm`'s `input` default is `hk` not the documented `slp1`, silently breaking 46.6% of a 500-headword stratified sample; 0% after the Salt-scoped fix), confirmed a structural entry-granularity gap (local = per-`lnum` record, live C-SALT = per-`hom` headword with merged `sense[]` — the real content of the "Phase 5" TODO), logged a GraphQL camelCase-casing gap (not fixed, API-shape call), started `/MW/{ref}` clean-URL routing (`cleanurl.php`, whitelist=mw), and found a doc/data mismatch in `doc/cleanurl.md`'s own worked example. Full report: [`csl-apidev/reports/salt_parity_mw_2026-07.md`](https://github.com/sanskrit-lexicon/csl-apidev/blob/master/reports/salt_parity_mw_2026-07.md). Live C-SALT re-verification beyond 2 hand-checked words is blocked by host rate-limiting — logged in [Uprava/SERVER_OUTAGES.md](https://github.com/gasyoun/Uprava/blob/main/SERVER_OUTAGES.md).
 - [x] SPEC-4: siglum fold-rule fix + curated-table integration in csl-atlas ([SPEC-4](https://github.com/sanskrit-lexicon/MWS/blob/master/planning/specs/2026-07/SPEC-4-siglum-apply.md)) — **✅ done 08-07-2026** (Sonnet 5 `claude-sonnet-5`, [csl-atlas#231](https://github.com/sanskrit-lexicon/csl-atlas/pull/231) merged). `foldSiglum`/`fold_siglum` strip locator suffixes for a verified-collision-free 22-base allowlist (a generic roman-numeral regex was tried and rejected — it corrupted `ratnam`/`mahav`/`sabdac`/`sabdam`/`harsac`); `source-siglum.mjs` now reads the curated `src/data/dicts/dict-source-aliases.json` instead of the stale June-10 seed; `siglum_families.py` generator emits per-family curated status; `data/obs/siglum_family_candidates.csv` regenerated 266→261 rows; new `data/obs/siglum_uncertain_evidence.csv` (per-dict raw-form evidence for the 6 quarantined keys, no merging); NFC-normalization shim added to `normalizeSource()`. 233/233 tests green, build green, no curated verdict re-adjudicated.
 - [ ] SPEC-5: #217 verdict application (GATED on maintainer ack) + #86 correction queue + #215 lex-type inventory + close #168/#90 ([SPEC-5](https://github.com/sanskrit-lexicon/MWS/blob/master/planning/specs/2026-07/SPEC-5-w1a-residuals-hygiene.md))
-- [ ] @DO (M.G., longest human lead time — **now the A16 critical path**): citation verification for PAPER.md
-  references flagged in A16 review Major 5 (Schreyer 1985, Funderburk et al. 2014,
-  Hausmann 1985, Wiegand 1989 pages, Wiegand 1995, 4 × A&R page cites).
+- [x] @DO (M.G.): citation verification for PAPER.md references flagged in A16 review
+  Major 5 (Schreyer 1985, Funderburk et al. 2014, Hausmann 1985, Wiegand 1989 pages,
+  Wiegand 1995, 4 × A&R page cites) — **✅ done**: pre-verification dossier built and
+  corrections applied in H1077 ([#244](https://github.com/sanskrit-lexicon/MWS/pull/244)),
+  a follow-up citation fix in [#245](https://github.com/sanskrit-lexicon/MWS/pull/245), and
+  the dossier author-signed with no vetoes, closing Major 5 ([#249](https://github.com/sanskrit-lexicon/MWS/pull/249)).
   ~~Scharf & Hyman 2009–11~~ **closed 03-07** — replaced with the web-verified
   Scharf & Hyman (2011) *Linguistic Issues in Encoding Sanskrit* in [#227](https://github.com/sanskrit-lexicon/MWS/pull/227).
 - [ ] [#195](https://github.com/sanskrit-lexicon/MWS/issues/195) docs-pass → master merge: ruled end-of-July default absent maintainer objection (Fable S2).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,5 +1,14 @@
 # MWS Roadmap — 2026 H2
 
+_Last touched: 08-07-2026 · staleness note added 29-07-2026 (H1877)_
+
+> **Staleness note (29-07-2026):** this file's W1–W4 narrative prose predates
+> ~30+ subsequent commits (A16/A17/A18/A39/A45/A46 paper work, H1077's Major-5
+> citation dossier, H1379/H1380, the `root_crosswalk`↔WhitneyRoots-canonical
+> join sync). Treat the prose below as a snapshot, not current status — verify
+> against [`.ai_state.md`](https://github.com/sanskrit-lexicon/MWS/blob/master/.ai_state.md) and `git log` before acting on any
+> single workstream description here.
+
 Forward plan for June–November 2026, superseding the 2026-05-27 snapshot.
 It sequences four workstreams chosen 2026-06-12 and bakes in a model-tier
 policy so that frontier-model (Fable-class) sessions are spent only where


### PR DESCRIPTION
## Summary
- `.ai_state.md`: the Major-5 PAPER.md citation-verification @DO (Schreyer 1985, Funderburk et al. 2014, Hausmann 1985, Wiegand 1989/1995, A&R page cites) was still listed OPEN despite being closed via H1077 (PR #244, #245, #249 — dossier pre-verified, corrections applied, author-signed with no vetoes). Flipped to done with the PR trail.
- `ROADMAP.md`: added a staleness banner — the W1-W4 narrative (last touched 08-07-2026) predates ~30+ subsequent commits (A16/A17/A18/A39/A45/A46 paper work, H1077, H1379/H1380, root_crosswalk/WhitneyRoots-canonical join sync). No rewrite of the roadmap body itself, just an honest flag pointing at `.ai_state.md` Completed log + `git log`.

Part of the multi-repo H1877 roadmap-drift sweep.

## Test plan
- [x] Verified via `git log --grep="Major-5"` and `git log --oneline | grep -i 1077` that H1077 (#244/#245/#249) actually closed the citation dossier before editing
- [x] Verified via `git log --oneline -35` that 30+ commits postdate the roadmap's last touch