### PR TITLE
add/upgrade .pre-commit-config.yaml (mixed-line-ending lf)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,3 +7,5 @@ repos:
       - id: trailing-whitespace
         args: [--markdown-linebreak-ext=md]
       - id: check-merge-conflict
+      - id: mixed-line-ending
+        args: [--fix=lf]


### PR DESCRIPTION
check-yaml/end-of-file-fixer/trailing-whitespace/check-merge-conflict/mixed-line-ending --fix=lf (+ruff syntax check on Python repos). Content-aware: upgrades existing configs that lack mixed-line-ending. Per cologne_batch_deploy.py (pre-commit), H2004.