### PR TITLE
docs(roadmap): regularise the date line into the house header form (H3002 slice 4)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,19 @@
 # MWS Roadmap — 2026 H2
 
-_Last touched: 08-07-2026 · staleness note added 29-07-2026 (H1877)_
+_Created: 23-05-2026 · Last updated: 27-08-2026_
+
+_Prose last touched 08-07-2026 · staleness note added 29-07-2026 (H1877) · header
+regularised 27-08-2026 (H3002)._
+
+> **Slice-4 note, 27-08-2026 (Opus 5 `claude-opus-5`, [H3002](https://github.com/gasyoun/Uprava/blob/main/handoffs/archive/H3002-Opus_multi_stale-roadmap-s4-cologne-ask-replan_17.08.26.md)).**
+> This pass regularised the date line into the house `_Created … Last updated_` form (it was
+> the only Cologne roadmap dated in an ad-hoc shape) and changed **nothing else**. The
+> staleness note below is this file's last substantive edit, made by
+> [H1877 (Sonnet 5) — multi-repo roadmap-drift sweep, Cologne cluster](https://github.com/gasyoun/Uprava/blob/main/handoffs/archive/H1877-Sonnet_multi_roadmap-drift-sweep-cologne-cluster_29.07.26.md),
+> and the slice-4 programme explicitly forbids re-opening H1877–H1880's catalogue — so the
+> W1–W4 prose is deliberately left as the snapshot that note already declares it to be, with
+> its own instruction to verify against `.ai_state.md` and `git log` standing unchanged. The
+> file carries no open checkboxes.
 
 > **Staleness note (29-07-2026):** this file's W1–W4 narrative prose predates
 > ~30+ subsequent commits (A16/A17/A18/A39/A45/A46 paper work, H1077's Major-5


### PR DESCRIPTION
Stale-roadmap slice 4 ([H3002](https://github.com/gasyoun/Uprava/blob/main/handoffs/H3002-Opus_multi_stale-roadmap-s4-cologne-ask-replan_17.08.26.md), Opus 5 `claude-opus-5`). One header line — **nothing else changed, deliberately**.

[`ROADMAP.md`](https://github.com/sanskrit-lexicon/MWS/blob/master/ROADMAP.md) was the only Cologne roadmap dated in an ad-hoc shape (`_Last touched: 08-07-2026 · staleness note added 29-07-2026 (H1877)_`) rather than the house `_Created … Last updated_` form, so [Uprava's `ROADMAP_INDEX.md`](https://github.com/gasyoun/Uprava/blob/main/ROADMAP_INDEX.md) carries an em dash in its *Updated* column and it cannot be aged. Creation date **23-05-2026**, from `git log --follow --diff-filter=A`. Both old facts are kept verbatim on their own line — the header replaces the shape, not the information.

**Why the W1–W4 prose is untouched.** This file's last substantive edit is the staleness note itself, added by [H1877 (Sonnet 5) — multi-repo roadmap-drift sweep, Cologne cluster](https://github.com/gasyoun/Uprava/blob/main/handoffs/archive/H1877-Sonnet_multi_roadmap-drift-sweep-cologne-cluster_29.07.26.md), and the slice-4 programme's own fence forbids re-opening the H1877–H1880 catalogue. The note already declares the prose a snapshot and already tells the reader to verify against `.ai_state.md` and `git log` before acting on any workstream description — which is the honest state, so re-asserting it would be the defect. The file has **no open checkboxes**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)