### PR TITLE
docs(claude): H4579 truth refresh — claims verified vs live clone

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,9 +1,9 @@
 # CLAUDE.md
 
-_Created: 06-05-2026 · Last updated: 05-09-2026_
+_Created: 06-05-2026 · Last updated: 12-09-2026_
 
-**MWS** is the correction, enhancement, and tooling layer for the Cologne
-digitisation of Monier-Williams, *A Sanskrit-English Dictionary* (1899).
+This repo is **MWS**, the correction, enhancement, and tooling layer for the
+Cologne digitisation of Monier-Williams, *A Sanskrit-English Dictionary* (1899).
 Canonical digitised source is
 `csl-orig/v02/mw/mw.txt`
 (SLP1), a sibling checkout on this machine (`../csl-orig/v02/mw/mw.txt`).
@@ -19,7 +19,7 @@ Tag reference: [DATA_DICTIONARY.md](https://github.com/sanskrit-lexicon/MWS/blob
 **Projects 5–8** (not 1–4) — 1–4 were already taken when MWS was onboarded.
 Taxonomy itself is the org standard.
 
-## What to run
+## How to run
 
 Transcode (`mwtranscode/`):
 
@@ -36,7 +36,8 @@ sh generate_dict.sh mw ../../mw
 sh xmlchk_xampp.sh mw
 ```
 
-On Windows without `xmllint`, `make_xml.py` printing
+On Windows without `xmllint`, the build's assembled
+`<outdir>/pywork/make_xml.py` printing
 `All records parsed by ET` is the validate signal.
 
 Issue folders under `mwsissues/issueNNN/` snapshot `mw.txt` to


### PR DESCRIPTION
## H4579 — CLAUDE.md truth refresh (STALE_22d)

**Verification pass (all claims re-checked vs live clone, 12-09-2026):**

| Claim | Result |
|---|---|
| `../csl-orig/v02/mw/mw.txt` sibling | ✅ exists |
| `csl-pywork/v02/generate_dict.sh` + `xmlchk_xampp.sh` | ✅ exist, usage matches |
| `mw_transcode.py slp1 roman|deva in out` (4 argv) | ✅ argv order confirmed in source |
| change-file `NNN old`/`NNN new` paired format | ✅ spot-checked issue182/change_2.txt |
| `mwsissues/issue182/updateByLine.py`, `mwtranscode/revdoc/updateByLine.py` | ✅ exist |
| `homophone/pywork/pykeysxml/extract_keys*.py`, frozen | ✅ exist; manual line 129 confirms Frozen |
| 5 external GitHub links (csl-pywork, csl-corrections workflow, spine primer, 2 claude-config commands) | ✅ all resolve via API |

**Changes (6+/5−):**
1. Date header 05-09 → 12-09-2026
2. Purpose phrasing: 'This repo is **MWS**…'
3. '## What to run' → '## How to run'
4. Validate signal clarified: the build's assembled `<outdir>/pywork/make_xml.py` (it is not a file in csl-pywork/v02/ — confirmed absent there; present only in the assembled pywork tree per generate_dict.sh internals)

**Note:** agent_docs_freshness --check already passed MWS before this PR (SLA clock anchored to origin/master commit c582e9d, 05-09, via H4147). The handoff's STALE_22d premise was computed against the non-default `main` branch. This PR re-anchors the clock to 12-09 and lifts the grade's MISSING_what+run flags.